### PR TITLE
upgrade to latest version of s3rver and add option for extra args

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,11 @@
 FROM mhart/alpine-node:latest
 RUN apk add --no-cache git
-RUN npm install -g s3rver@3.5.0
+RUN npm install -g s3rver@3.6.0
 RUN npm install aws-sdk
 WORKDIR /
 COPY CORS.xml /CORS.xml
 EXPOSE 5000
-CMD s3rver -a 0.0.0.0 --port 5000 --allow-mismatched-signatures --directory /tmp --configure-bucket "$S3_BUCKET_NAME" /CORS.xml
+CMD s3rver -a 0.0.0.0 --port 5000 \
+    --allow-mismatched-signatures \
+    --directory /tmp \
+    --configure-bucket "$S3_BUCKET_NAME" /CORS.xml $S3RVER_EXTRA_ARGS

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 Docker image with latest version of S3 fake service ( https://github.com/jamhall/s3rver ).
 
+You can set extra  the ``S3RVER_EXTRA_ARGS`` environment variable to set extra arguments.
+For example, if you want to use the S3 path-style address, set ``S3RVER_EXTRA_ARGS=--no-vhost-buckets``
+
 ## Usage with Vagrant
 
 Set the bucket name environment variable in your Vagrantfile.


### PR DESCRIPTION
Bonjour,

Summary of changes:

* upgraded to the latest version of s3rver
* added an env variable to allow passing extra arguments
* documented how to use the env variable to enable path-style behavior for the bucket using the newly added `--no-vhost-buckets` option: https://github.com/jamhall/s3rver/pull/632 (main motivation for this)

Does this look good?